### PR TITLE
osef du crew dans la nav

### DIFF
--- a/src/_partials/nav.hbs
+++ b/src/_partials/nav.hbs
@@ -12,7 +12,6 @@
 				<li class=""><a class="putainde-Nav-list-item {{#is this.nav 'wat' }}putainde-Nav-list-item--active{{/is}}" href="c-est-quoi-putaindecode">Putain de ... ?</a>
         <li class=""><a class="putainde-Nav-list-item {{#is this.nav 'posts' }}putainde-Nav-list-item--active{{/is}}" href="posts">Les Posts</a>
 				<li class=""><a class="putainde-Nav-list-item {{#is this.nav 'contribute' }}putainde-Nav-list-item--active{{/is}}" href="posts/comment-contribuer/">Comment Contribuer ?</a>
-				<li class=""><a class="putainde-Nav-list-item {{#is this.nav 'about' }}putainde-Nav-list-item--active{{/is}}" href="le-crew">Le Crew</a>
 			</ul>
 		</div>
 	</div>


### PR DESCRIPTION
Le petit lien du footer suffit.
De plus cette page ne reflète clairement pas ceux qui s’implique. Une
réorganisation de la homepage va suivre.
