### PR TITLE
Fix callback naming

### DIFF
--- a/pages/posts/js/introduction-au-testing-js-front/index.md
+++ b/pages/posts/js/introduction-au-testing-js-front/index.md
@@ -126,7 +126,7 @@ module.exports = {
   release : function(){
     eventbus.stopListening("addToCart", this._addToCart)
   },
-  addToCart : function(eventObject){
+  _addToCart : function(eventObject){
     // et on a eventObject.id
     this.products.push(catalog[eventObject.currentTarget.data("id")])
   }


### PR DESCRIPTION
The event registrations refer to a prefixed `this._addToCart`

The change could be made the other way around.
