### PR TITLE
Fix: npm: choisir la bonne version de ses dépendances

### DIFF
--- a/pages/posts/nodejs/npm-choisir-version/index.md
+++ b/pages/posts/nodejs/npm-choisir-version/index.md
@@ -75,7 +75,7 @@ Il est clair que lu comme ça, le plus intéressant est le `^` et c'est justemen
 
 Pour plus d'information sur la définition des versions, [c'est par là](https://github.com/isaacs/node-semver#ranges) (Oh mon dieu, il a fait un lien avec un "cliquez ici").
 
-Bon. C'est bon ? Vous avez tout compris ? Okay, vous pouvez passer à [**napa**](/posts/npm/napa-ou-comment-telecharger-package-napa-package-json/) maintenant qui vous aidera grandement sur le téléchargement de projets n'ayant pas de `package.json`.
+Bon. C'est bon ? Vous avez tout compris ? Okay, vous pouvez passer à [**napa**](/posts/nodejs/napa-ou-comment-telecharger-package-napa-package-json/) maintenant qui vous aidera grandement sur le téléchargement de projets n'ayant pas de `package.json`.
 
 En ce qui concerne npm, je m'arrête là, et vous propose une petite solution afin d'augmenter la vitesse de vos installations de node modules.
 


### PR DESCRIPTION
The link to the blog post "napa ou comment télécharger un package qui napa de package.json" was wrong (the link target the "npm" section instead of the "nodejs" section).
