### PR TITLE
Fix: le point sur les preprocesseurs

### DIFF
--- a/pages/posts/css/le-point-sur-les-preprocesseurs/index.md
+++ b/pages/posts/css/le-point-sur-les-preprocesseurs/index.md
@@ -242,4 +242,4 @@ vous pourrez continuer la lecture au prochain épisode qui sera consacré aux po
 <small>(Mamam, t'as vu ce cliffhanger digne des séries US !)</small>
 
 ~~Bon promis la prochaine fois je vous en parle des post-processeurs. Pour de vrai.~~
-Chose promise, chose due : [Les post-processeurs CSS](http://putaindecode.fr/posts/css/les-post-processeurs/)
+Chose promise, chose due : [Les post-processeurs CSS](/posts/css/les-post-processeurs/)


### PR DESCRIPTION
Rajout d'un lien vers /posts/css/les-post-processeurs qui n'existait pas au moment de l'écriture de cet article.
