### PR TITLE
Fix: les post processeurs

### DIFF
--- a/pages/posts/css/les-post-processeurs/index.md
+++ b/pages/posts/css/les-post-processeurs/index.md
@@ -206,4 +206,4 @@ J'aime conserver la syntaxe CSS et avoir un process ultra-rapide et transparent.
 
 ### Prochaine étape: faire son propre pré/post-processeur CSS, c'est simple
 
-Rework ayant un bon petit paquet de plugins déjà existants, c'est assez simple de [réaliser son propre pré-processeur](http://putaindecode.fr/posts/css/preprocesseur-a-la-carte/) via quelques lignes de code seulement.
+Rework ayant un bon petit paquet de plugins déjà existants, c'est assez simple de [réaliser son propre pré-processeur](/posts/css/preprocesseur-a-la-carte/) via quelques lignes de code seulement.


### PR DESCRIPTION
Rajout d'un lien vers /posts/css/preprocesseur-a-la-carte/ qui n'existait pas au moment de l'écriture de cet article.
