### PR TITLE
Fix: gitignore npm-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules
 dist
 .publish
 stylesheets/icons
+
+# log
+npm-debug.log


### PR DESCRIPTION
Ajout de npm-debug.log dans gitignore
