### PR TITLE
Fix: Remove extra bracket in the RSS feed template

### DIFF
--- a/mixins/feedPosts.jade
+++ b/mixins/feedPosts.jade
@@ -6,7 +6,7 @@ mixin FeedPosts()
     item
       title #{post.title}
       description
-        | <![CDATA[[
+        | <![CDATA[
         | !{getFeedDescription(post.slug)}
         | ]]>
       pubDate #{(new Date(post.date)).toUTCString()}


### PR DESCRIPTION
There was an extra bracket in the RSS feed template, which causes a display problem in feed readers.

![Putain de Code in Press Android](http://i.imgur.com/iAjRLCVl.png)
