### PR TITLE
Run publish when I commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,15 @@ notifications:
       - https://webhooks.gitter.im/e/1963aded18e129703057
     on_start: true
 
+# http://docs.travis-ci.com/user/caching/
 cache:
   directories:
     - node_modules
+
+# http://docs.travis-ci.com/user/build-configuration/
+script: npm run travis
+
+env:
+  global:
+    # MoOx
+    - secure: 4PEqVqjHxXE6qQ3t+YoPyTrxT+3+W4il43NjCCdHrDucv5UQ3ceESoDxAFWO62W+HYGpp71zUxyiU+afgMjskwvAO1AFXvu6MBVuo3DycmD4uNChUGFAeBapM6Kul4Y+A8MXoo21//8yFX3oDvCa/VC3pRKp4utx2JhDDLl1dOM=

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -51,6 +51,4 @@ gulp.task("default", [
 ])
 
 // publish
-gulp.task("publish", [
-  "dist"
-], require("./tasks/publish"))
+gulp.task("publish", ["dist"], require("./tasks/publish"))

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "production": "gulp --production",
     "publish": "gulp publish --production",
     "deploy": "npm run publish",
-    "test": "gulp dist --production"
+    "test": "gulp dist --production",
+    "travis": "if [ '$(git branch | grep \\* | tail -c +3)' != 'master' ]; then npm test; else npm run publish; fi;"
   },
   "devDependencies": {
     "async": "^0.7.0",


### PR DESCRIPTION
Now when we commit, we try to publish when it’s on master branch,
otherwise just try the build.

Other owners will add to add their own secure encrypted key:

```
GH_USERNAME=YOUR_GITHUB_USERNAME
GH_BRANCH=gh-pages

curl -u $GH_USERNAME -d "{\"scopes\":[\"public_repo\"],\"note\":\"push to $GH_BRANCH from travis\"}" https://api.github.com/authorizations
```

You will be asked to enter your password.

Then you will have something like this

```
{
  "id": 123456,
  "url": "https://api.github.com/authorizations/8955171",
  "app": {
    "name": "push to gh-pages from travis (API)",
    "url": "https://developer.github.com/v3/oauth_authorizations/",
    "client_id": "00000000000000000000"
  },
  "token": "YOUR_AWESOME_TOKEN",
  "note": "push to gh-pages from travis",
  "note_url": null,
  "created_at": "2014-05-29T03:55:28Z",
  "updated_at": "2014-05-29T03:55:28Z",
  "scopes": [
    "public_repo"
  ]
}
```

Now you will need travis encrypt command that you can get with the ruby
gem `travis` (that have an `encrypt` command) or the npm package
`travis-encrypt`.
For the commands below, lines prefixed by # are for ruby gem, the
following line will be npm version (since I’ve used this one, I’m sure
it as worked - I will see after this commit :D)

```
#gem install travis
npm i -g travis-encrypt
```

Then continue with (replace YOUR_AWESOME_TOKEN by your actual token)

```
GH_REPOSITORY="putaindecode/website"
GH_TOKEN=YOUR_AWESOME_TOKEN
#travis encrypt -r $GH_REPOSITORY GH_TOKEN=$GH_TOKEN
travis-encrypt -r $GH_REPOSITORY -k GH_TOKEN -v $GH_TOKEN
```

You will get a travis specific token that you should now add in the
env.global section (with your nick please).

---

Cette PR est un bon example. [Le build lié](https://travis-ci.org/putaindecode/website/builds/26275338) nous montre bien que `npm run travis` n'a que joué le build, sans faire le publish.
Maintenant on va merger et voir si ça publish bien :)

![](http://www.reactiongifs.com/wp-content/uploads/2012/11/fingers-crossed.gif)

---

Edit: bon déjà j'ai voulu faire le malin avec les commandes shell dans les `package.json/scripts`...
Fixed in https://github.com/putaindecode/website/commit/79df24dca9da127fe8a73a080e0417312c0fd143

`package.json`

``` diff
-    "travis": "if [ '$(git branch | grep \\* | tail -c +3)' != 'master' ]; then npm test; else npm run publish; fi;"
+    "travis": "if [ \"$(git branch | grep \\* | tail -c +3)\" != \"master\" ]; then npm test; else npm run publish; fi;"
```

Edit 2: 
- Travis est sur une branche détaché (cf [build de debug](https://travis-ci.org/putaindecode/website/builds/26275916))
- en fait y'a une super variable d'env TRAVIS_BRANCH ([doc](http://docs.travis-ci.com/user/ci-environment/#Environment-variables))

Fixed in d5f4de3c2f1f98d3f7b6d68aeb8f06f911521122
`package.json`

``` diff
-    "travis": "if [ \"$(git branch | grep \\* | tail -c +3)\" != \"master\" ]; then npm test; else npm run publish; fi;"
+    "travis": "if [ \"$TRAVIS_BRANCH\" != \"master\" ]; then npm test; else npm run publish; fi;"
```

Edit 3:
Ensuite il manquait l'auth complète pour Travis
Fixed in b79267326c2d274390d7a65165e541b296e612ca

`.travis.yml`

``` diff
-script: npm run travis
+script:
+  # we need --global because of how gulp-gh-pages works (with another clone elsewhere)
+  - git config --global user.name "Travis-CI"
+  - git config --global user.email "mail+travis@putaindecode.fr"
+  - npm run travis
```

`tasks/publish.js`

``` diff
-      remoteUrl : "git@github.com:putaindecode/website.git",
+      remoteUrl : "https://" + (process.env.GH_TOKEN ? process.env.GH_TOKEN + "@" : "") + "github.com/putaindecode/website.git",
```
