### PR TITLE
Ajout d'une référence utile pour le post sur Flux

### DIFF
--- a/src/pages/posts/js/flux-qu-est-ce-c-est/index.md
+++ b/src/pages/posts/js/flux-qu-est-ce-c-est/index.md
@@ -2,7 +2,7 @@ Allez, tant pis, on saute l'intro et on entre directement dans le vif du sujet (
 
 ## La petite histoire
 
-Il était une fois un gros site web *que s'apelorio* Facebook. Qui dit Facebook, dit webapp plus grosse que la plus grosse de tes copines <sup>[1](#foonote-1)</sup> ; et du coup, propension à se retrouver submergé de bugs plus élevée.
+Il était une fois un gros site web *que s'apelorio* Facebook. Qui dit Facebook, dit webapp plus grosse que la plus grosse de tes copines (*no offense* <sup>[1](#foonote-1)</sup>) ; et du coup, propension à se retrouver submergé de bugs plus élevée.
 
 Les ingénieurs front-end de Facebook, confrontés à une codebase de plus en plus bordélique (personne ne voulant toucher certaines parties de celle-ci) ont dû repenser la structure des composants les plus cruciaux.
 
@@ -213,5 +213,5 @@ Pour aller un peu plus loin :
 - [Le repository Flux](https://github.com/facebook/flux) et ses différents exemples.
 
 <small>
-  <a id="foonote-1"></a>1: [Référence utile](https://www.youtube.com/watch?v=jRzv9gep5Ng&t=4m)
+  <a id="foonote-1"></a>1: [Référence utile (`ntm install reference`)](https://www.youtube.com/watch?v=jRzv9gep5Ng&t=4m)
 </small>


### PR DESCRIPTION
Pour faire suivre à la PR de @Korbik, je propose l'ajout d'un référence utile qui, je pense, vaut mieux qu'un _no offense_.

Note: Le rendu visuel est bon, cf ci dessous

![screen shot 2014-10-28 at 06 51 15](https://cloud.githubusercontent.com/assets/157534/4804156/7eddd280-5e66-11e4-928e-62303f4a643b.png)

![screen shot 2014-10-28 at 06 51 23](https://cloud.githubusercontent.com/assets/157534/4804157/7ee10b80-5e66-11e4-951d-b61a6344e01d.png)
