### PR TITLE
Smaller top contributors section

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -132,8 +132,8 @@ const webpackConfig = {
     ],
   },
 
-  postcss: () => [
-    require("postcss-import"),
+  postcss: (webpack) => [
+    require("postcss-import")({ addDependencyTo: webpack }),
     require("postcss-cssnext"),
   ],
 

--- a/web_modules/Author/index.js
+++ b/web_modules/Author/index.js
@@ -12,15 +12,25 @@ export default class Author extends Component {
   }
 
   static propTypes = {
-    className: PropTypes.string,
     author: PropTypes.string.isRequired,
+    className: PropTypes.string,
     afterName: PropTypes.string,
     isPost: PropTypes.bool,
+    bio: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    bio: true,
   }
 
   render() {
     const { metadata } = this.context
     const i18n = metadata.i18n
+    const {
+      afterName,
+      isPost,
+      bio,
+    } = this.props
     const author = metadata.contributors.getContributor(this.props.author)
 
     return (
@@ -35,7 +45,7 @@ export default class Author extends Component {
           <div className="putainde-Author-title">
             <h3 className="putainde-Author-name">
               {
-                this.props.isPost &&
+                isPost &&
                 <span className="putainde-WrittenBy">
                   {`${i18n.writtenBy} `}
                 </span>
@@ -44,12 +54,12 @@ export default class Author extends Component {
                 className="putainde-Link"
                 href={getAuthorUri(author)}
               >
-                {author.login}
+                { author.login }
               </a>
               {
-                this.props.afterName &&
+                afterName &&
                 <span className="putainde-Author-afterName">
-                  {` ${this.props.afterName}`}
+                  {` ${afterName}`}
                 </span>
               }
             </h3>
@@ -100,13 +110,16 @@ export default class Author extends Component {
             </div>
           </div>
 
-          <p className="putainde-Author-bio">
-            {
-              (author.fr && author.fr.bio && author.fr.bio.long) &&
-              author.fr.bio.long
-              /* @todo add new lines betwee lines */
-            }
-          </p>
+          {
+            bio &&
+            <p className="putainde-Author-bio">
+              {
+                (author.fr && author.fr.bio && author.fr.bio.long) &&
+                author.fr.bio.long
+                /* @todo add new lines betwee lines */
+              }
+            </p>
+          }
         </div>
       </div>
     )

--- a/web_modules/Contributor/index.js
+++ b/web_modules/Contributor/index.js
@@ -1,0 +1,44 @@
+import React, { Component, PropTypes } from "react"
+import cx from "classnames"
+
+import Avatar from "../Avatar"
+
+export default class Contributors extends Component {
+
+  static propTypes = {
+    author: PropTypes.string.isRequired,
+    commits: PropTypes.string,
+    size: PropTypes.string,
+  }
+
+  render() {
+    const {
+      author,
+      commits,
+      size,
+    } = this.props
+
+    return (
+      <div
+        key={ author }
+        className={ cx(
+          "putainde-Contributor",
+          "r-Tooltip",
+          "r-Tooltip--bottom",
+          "r-Tooltip--allowNewLines"
+        ) }
+        data-r-tooltip={ [
+          author,
+          `(${ commits } commit${ commits > 1 ? "s" : "" })`,
+        ].join("\n") }
+      >
+        <Avatar
+          author={ author }
+          className={
+            `putainde-Contributor-avatar${ size ? `--${ size }` : "" }`
+          }
+        />
+      </div>
+    )
+  }
+}

--- a/web_modules/Contributors/index.js
+++ b/web_modules/Contributors/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from "react"
-import cx from "classnames"
 
-import Avatar from "../Avatar"
+import Contributor from "Contributor"
 
 export default class Contributors extends Component {
 
@@ -97,25 +96,11 @@ export default class Contributors extends Component {
               console.warn(`${filename} have an undefined contributor.`)
             }
             return (
-              <div
-                key={login}
-                className={cx(
-                  "putainde-Contributor",
-                  "r-Tooltip",
-                  "r-Tooltip--bottom",
-                  "r-Tooltip--allowNewLines"
-                )}
-                data-r-tooltip={
-                  `${login}\n(${fileContributors[login]} commit${
-                    fileContributors[login] > 1 ? "s" : ""
-                  })`
-                }
-              >
-                <Avatar
-                  author={login}
-                  className="putainde-Contributor-avatar"
-                />
-              </div>
+              <Contributor
+                author={ login }
+                commits={ fileContributors[login] }
+                size={ "small" }
+              />
             )
           })
         }

--- a/web_modules/LatestPosts/index.js
+++ b/web_modules/LatestPosts/index.js
@@ -20,7 +20,7 @@ export default class LatestPosts extends Component {
     return (
       <div>
         <div className="r-Grid putainde-Section">
-          <div className="r-Grid-cell r-all--8of12 putainde-Section-contents">
+          <div className="r-Grid-cell r-minM--8of12 putainde-Section-contents">
             <div className="putainde-Title putainde-Title--home">
               <h2 className="putainde-Title-text">
                 {i18n.latestPosts}
@@ -30,7 +30,7 @@ export default class LatestPosts extends Component {
           </div>
         </div>
         <div className="r-Grid" style={{ textAlign: "center" }}>
-          <div className="r-Grid-cell r-all--8of12 ">
+          <div className="r-Grid-cell r-minM--8of12">
             <Link
               to="/fr/articles"
               className="putainde-Button putainde-Button--block"

--- a/web_modules/Layout/Homepage/index.js
+++ b/web_modules/Layout/Homepage/index.js
@@ -60,7 +60,7 @@ class Homepage extends Component {
             <div
               className={cx(
                 "r-Grid-cell",
-                "r-all--8of12",
+                "r-minM--8of12",
                 "putainde-Section-contents",
                 "putainde-Post-contents"
               )}

--- a/web_modules/Layout/Page/index.js
+++ b/web_modules/Layout/Page/index.js
@@ -28,7 +28,7 @@ export default class Page extends Component {
           ]}
         />
         <article className="r-Grid putainde-Post">
-          <div className="r-Grid-cell r-all--8of12 putainde-Post-contents">
+          <div className="r-Grid-cell r-minM--8of12 putainde-Post-contents">
 
             {
               head.title &&

--- a/web_modules/Layout/PageError/index.js
+++ b/web_modules/Layout/PageError/index.js
@@ -25,7 +25,7 @@ export default class PageError extends Component {
           ]}
         />
         <div className="r-Grid putainde-Post">
-          <div className="r-Grid-cell r-all--8of12">
+          <div className="r-Grid-cell r-minM--8of12">
             <div
               className="putainde-Post-contents"
               style={{ textAlign: "center" }}

--- a/web_modules/Layout/Post/index.js
+++ b/web_modules/Layout/Post/index.js
@@ -215,7 +215,7 @@ export default class Post extends Component {
           </header>
 
           <div className="r-Grid">
-            <div className="r-Grid-cell r-all--8of12 putainde-Post-contents">
+            <div className="r-Grid-cell r-minM--8of12 putainde-Post-contents">
               <div className="putainde-Post-md">
                 <div
                   dangerouslySetInnerHTML={{ __html: body }}

--- a/web_modules/Layout/Posts/index.js
+++ b/web_modules/Layout/Posts/index.js
@@ -52,7 +52,7 @@ class Posts extends Component {
           <div
             className={cx(
               "r-Grid-cell",
-              "r-all--8of12",
+              "r-minM--8of12",
               "putainde-Section-contents",
               "js-Posts"
             )}

--- a/web_modules/TopContributors/index.js
+++ b/web_modules/TopContributors/index.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react"
 
-import Author from "../Author"
+import Contributor from "Contributor"
 
 export default class TopContributors extends Component {
 
@@ -33,12 +33,15 @@ export default class TopContributors extends Component {
           </small>
         </div>
 
-        <div className="r-Grid r-Grid--withGutter">
+        <div
+          className="r-Grid r-Grid--withGutter"
+          style={ { textAlign: "center" } }
+        >
           {
             !topContributors.length &&
             <p
               className="r-Grid-cell"
-              style={ { textAlign: "center", opacity: .5 } }
+              style={ { opacity: .5 } }
             >
               { i18n.topContributorsNoData }
             </p>
@@ -47,12 +50,13 @@ export default class TopContributors extends Component {
             topContributors.length &&
             topContributors.map(author => {
               return (
-                <div key={author} className="r-Grid-cell r-all--1of2">
-                  <Author
-                    author={author}
-                    afterName={
-                      `(${contributors.recentContributions[author]} commits)`
-                    }
+                <div
+                  key={author}
+                  className="r-Grid-cell r-maxM--1of4 r-minM--1of8"
+                >
+                  <Contributor
+                    author={ author }
+                    commits= { contributors.recentContributions[author] }
                   />
                 </div>
               )

--- a/web_modules/css/base/responsive.css
+++ b/web_modules/css/base/responsive.css
@@ -8,13 +8,3 @@
   margin-left: auto;
   margin-right: auto;
 }
-
-@media (--r-maxM) {
-  .r-Grid {
-    width: auto;
-  }
-  .r-Grid-cell {
-    width: auto !important;
-    display: block !important;
-  }
-}

--- a/web_modules/css/blocks/contributors.css
+++ b/web_modules/css/blocks/contributors.css
@@ -27,6 +27,7 @@
     display: inline-block;
     margin: 0 0 1rem 1rem;
     vertical-align: middle;
+    transform: none;
   }
 
     .putainde-Contributor-avatar {

--- a/web_modules/css/blocks/contributors.css
+++ b/web_modules/css/blocks/contributors.css
@@ -25,7 +25,7 @@
 
   .putainde-Contributor {
     display: inline-block;
-    margin-left: 1rem;
+    margin: 0 0 1rem 1rem;
     vertical-align: middle;
   }
 

--- a/web_modules/css/blocks/contributors.css
+++ b/web_modules/css/blocks/contributors.css
@@ -30,6 +30,11 @@
   }
 
     .putainde-Contributor-avatar {
+      width: 4rem;
+      height: 4rem;
+    }
+
+    .putainde-Contributor-avatar--small {
       width: 2.5rem;
       height: 2.5rem;
     }


### PR DESCRIPTION
![screen shot 2015-11-16 at 07 38 19](https://cloud.githubusercontent.com/assets/157534/11175689/1f5770b6-8c35-11e5-8d53-ba52107cf85b.png)
![screen shot 2015-11-16 at 07 38 32](https://cloud.githubusercontent.com/assets/157534/11175690/1f57f2b6-8c35-11e5-88f9-605d65a9fe1c.png)

Because it's not that important after all.

I used the same avatar + name/commits in tooltip that we have on Post contributors section. Avatars here are just bigger.