### PR TITLE
Fix hoisting error

### DIFF
--- a/content/fr/articles/js/es2015/const-let-var.md
+++ b/content/fr/articles/js/es2015/const-let-var.md
@@ -134,13 +134,14 @@ pouvez écrire :
 
 ```javascript
 function fn() {
-  console.log(foo) // "bar"
+  console.log(foo) // undefined (au lieu de ReferenceError)
   var foo = "bar"
 }
 ```
 
 Concrètement, le moteur d'exécution JavaScript va lire toutes les déclarations
-et remonter celles avec `var` au début du scope de votre fonction.
+et remonter celles avec `var` au début du scope de votre fonction (attention,
+cela concerne les déclarations, pas les affectations).
 
 `let` et `const` ne bénéficient pas de ce mécanisme de hoisting, ce qui peut
 mener à des problèmes de TDZ (*Temporal Dead Zone*). Vu que la déclaration de


### PR DESCRIPTION
In latest article about let/const, there is a small error about hoisting

```js
console.log(x) // undefined, not "toto"
var x = "toto"
```