### PR TITLE
Strict mode clarification (EN)

### DIFF
--- a/content/en/articles/js/es2015/classes.md
+++ b/content/en/articles/js/es2015/classes.md
@@ -1,6 +1,6 @@
 ---
 date: "2015-12-05"
-title: "ES6, ES2015 : Classes"
+title: "ES6, ES2015: Classes"
 tags:
   - javascript
   - ES6
@@ -19,7 +19,7 @@ accessible.
 ## Class declaration
 
 Forget functions and prototypes, semantic is taking the relay as you will see in
-the following example :
+the following example:
 
 ```js
 class User {
@@ -33,7 +33,7 @@ class User {
   }
 }
 
-// instanciation
+// instantiation
 const user = new User("John", "Doe")
 
 // call of the method sayName()
@@ -42,7 +42,7 @@ console.log(user.sayName()) // John Doe
 
 As a reminder, here is one
 [way to code](https://gist.github.com/magsout/a876b2fa8240a987e523)
-this class in `es5` :
+this class in `ES5`:
 
 ```js
 function User(firstname, lastname) {
@@ -57,19 +57,19 @@ User.prototype.sayName = function() {
   return this.firstname + " " + this.lastname
 }
 
-// instanciation
+// instantiation
 var user = new User("John", "Doe")
 
 // call of the method sayName()
 console.log(user.sayName()) // John Doe
 ```
 
-## Classes expressions
+## Syntax
 
 All methods should be written as simple function inside the class.
-You might denote the nice way to write getter and setter :
+You might denote the nice way to write getter and setter:
 
-```JS
+```js
 class User {
   constructor(firstname, lastname, type) {
     this.firstname = firstname
@@ -93,7 +93,7 @@ class User {
   }
 }
 
-// the `new` is mandatory to instanciate a class
+// the `new` is mandatory to instantiate a class
 const user = new User("John", "Doe", "Contributor")
 
 console.log(user.sayName()) // John Doe
@@ -104,10 +104,10 @@ console.log(user.role) // Owner
 
 ## Inheritance
 
-In order to have a class that inherite from another, we have the `extends`
+In order to have a class that inherits from another, we have the `extends`
 keyword.
 
-Here is the an example :
+Here is the an example:
 
 ```js
 class Contributor extends User {
@@ -147,6 +147,16 @@ We just have a more readable code that should be more easily maintainable.
 For now, you will need to use a transpiler like [babel](https://babeljs.io/)
 to be able to use classes.
 
-One last thing: when you are in a class context,
-[strict mode](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Strict_mode)
-is enabled automatically.
+One last thing: the bodies of class declarations and class expressions are
+executed in
+[strict mode](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Strict_mode).
+
+```js
+/* Initial strict mode */
+class MyClass {
+  someMethod() {
+    /* Here we are in strict mode */
+  }
+}
+/* Still the initial strict mode */
+```


### PR DESCRIPTION
See #626 

Changes:

- No space before punctuators
- Typos on _instantiate_ and related words
- Removed an invalid title
- Added a snippet to illustrate strict mode