### PR TITLE
Ajout de « https:// » devant le lien vers le « playground » en ligne

### DIFF
--- a/content/fr/articles/swift/hello/index.md
+++ b/content/fr/articles/swift/hello/index.md
@@ -34,7 +34,7 @@ outils.
 
 Grâce à un partenariat entre Apple et IBM,  vous pouvez faire du **Swift sur
 votre navigateur** avec Bluemix. La plate-forme de cloud coding d'IBM
-[swiftlang.ng.bluemix.net](swiftlang.ng.bluemix.net) offre ainsi un
+[swiftlang.ng.bluemix.net](https://swiftlang.ng.bluemix.net) offre ainsi un
 **`playground` en ligne** pour apprendre et vous entrainer en **Swift**. Donc
 plus de limitation due à l'OS pour apprendre !
 


### PR DESCRIPTION
Cela permet d'éviter de se retrouver vers la page inexistante « http://putaindecode.io/fr/articles/swift/hello/swiftlang.ng.bluemix.net » quand on clique dessus.