### PR TITLE
Fix: ES6, ES2015 : les nouvelles méthodes d'Array

### DIFF
--- a/content/fr/articles/js/es2015/array-methods-addition.md
+++ b/content/fr/articles/js/es2015/array-methods-addition.md
@@ -90,8 +90,8 @@ partir de quel index on souhaite démarrer la copie de la séquence, ainsi que
 l'index de début et de fin de la séquence que l'on souhaite voir répétée.
 
 ```javascript
-const arr = ["hello","alice", "my", "name", "is" "bob"]
-console.log(arr.copyWithin(1, 5)]) //  "hello","bob", "my", "name", "is" "bob"]
+const arr = ["hello","alice", "my", "name", "is", "bob"]
+console.log(arr.copyWithin(1, 5)]) //  "hello","bob", "my", "name", "is", "bob"]
 ```
 
 Certaines méthodes ne paraissent pas forcément super utiles alors n'hésitez à


### PR DESCRIPTION
Ajout d'une virgule entre éléments d'un tableau sur l'exemple de « Array.prototype.copyWithin() »