### PR TITLE
Update arrow-functions.md

### DIFF
--- a/content/fr/articles/js/es2015/arrow-functions.md
+++ b/content/fr/articles/js/es2015/arrow-functions.md
@@ -147,7 +147,10 @@ le résultat attendu avec ce code :
 const aFn = obj => {
   key: obj.value;
 };
-console.log(aFn()); // undefined
+const anObj = {
+  value: 'my value'
+};
+console.log(aFn(anObj)); // undefined
 ```
 
 En effet, l'exemple ci-dessus pourrait être traduit en ES5 de la manière


### PR DESCRIPTION
Giving a object with a value obj will be more clear for this example as anyway without this example, js would return an error like 'Cannot read property 'value' of undefined'