### PR TITLE
Fix url for ReasonML, the old link lands on a redirect page

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ yarn prerender
 
 ## Liens utiles
 
-- [ReasonML](https://reasonml.github.io/docs/en/quickstart-javascript): la langage
+- [ReasonML](https://reasonml.github.io/docs/en/installation): la langage
 - [ReasonReact](https://reasonml.github.io/reason-react/docs/en/installation): La bibliothèque UI
 - [BuckleScript](https://bucklescript.github.io/docs/en/installation): le _compiler_
 - [Belt](https://bucklescript.github.io/bucklescript/api/Belt.html): la _standard library_


### PR DESCRIPTION
The old link go here => https://reasonml.github.io/docs/en/quickstart-javascript wich explicitely tell to change the link to https://reasonml.github.io/docs/en/installation wich is what this pull request does.