### PR TITLE
Add option and question mark post

### DIFF
--- a/articles/2019-05-26-type-option-et-point-d-interrogation.md
+++ b/articles/2019-05-26-type-option-et-point-d-interrogation.md
@@ -126,7 +126,7 @@ C’est aussi l’occasion d’aborder le fait de pouvoir renommer un argument a
 
 ### Inférence de type
 
-L’inférence de type est vraiment très bonne en Reason, si j’ai explicité le type option et leur contenu string, je peux très bien m’en passer. Ce qui nous donne un exemple finale moins verbeux :
+L’inférence de type est vraiment très bonne en Reason, si j’ai explicité le type option et leur contenu string, je peux très bien m’en passer. Ce qui nous donne un exemple final moins verbeux :
 
 ```reason
 /* User.re */
@@ -149,5 +149,5 @@ let make = (~name, ~avatarUrl as imageSrc=?) =>
 
 Le type option se révèle très pratique lors de l'écriture d'un fonction ou d'un component. Les paramètres optionnels, avec les deux syntaxes utilisant le point d'interrogation, permettent de ne pas complexifier l'usage de la fonction ou du component.
 
-Dans l'exemple final, l'implémentation de `User` n'a pas changé depuis le début car nous voulons gérer l'aspect facultatif du paramètre. En revanche `Follower` n'avait absoluement pas besoin de le gérer dans son implémentation, le code s'en serait trouvé inutilement alourdis.
+Dans l'exemple final, l'implémentation de `User` n'a pas changé depuis le début car nous voulons gérer l'aspect facultatif du paramètre. En revanche `Follower` n'avait absoluement pas besoin de le gérer dans son implémentation, le code s'en serait trouvé inutilement alourdi.
 Nous gardons ainsi une écriture fluide tout en permettant de gérer l'optionnalité d'une valeur lorsque cela est nécessaire.

--- a/articles/2019-05-26-type-option-et-point-d-interrogation.md
+++ b/articles/2019-05-26-type-option-et-point-d-interrogation.md
@@ -1,43 +1,43 @@
 ---
 date: 2019-05-26
-title: Type option et point d'interrogation
+title: ReasonML type option et passage optionnel
 author: freddy03h
-slug: type-option-et-point-d-interrogation
+slug: reasonml-type-option-et-passage-optionnel
 ---
 
-Le type option est vraiment super à utiliser en Reason, je vous conseil la lecture de [l’article de Matthias](/articles/introduction-a-reasonml) (et tous les autres articles sur Reason). Mais j’ai un peu buté sur un petit point, c'est celle de la **combinaison du type option** et de l’utilisation du **point d'interrogation** pour les **paramètres optionnels** d’une fonction ou d’un composant React [malgré la doc à ce sujet](https://reasonml.github.io/docs/en/function#optional-labeled-arguments), alors je résume cela dans cet article.
+Le type option est vraiment super à utiliser en Reason, je vous conseil la lecture de [l'introduction à reasonml](/articles/introduction-a-reasonml) (et tous les autres articles sur Reason). Mais j’ai un peu buté sur un petit point, c'est celle de la **combinaison du type option** et de l’utilisation du **point d'interrogation** pour les **paramètres optionnels** d’une fonction ou d’un composant React [malgré la doc à ce sujet](https://reasonml.github.io/docs/en/function#optional-labeled-arguments), alors je résume cela dans cet article.
 
-On va prendre comme exemple un composant `UserRow` qui prend en paramètre un `name` et une `imageSrc` qui peut être facultative.
+On va prendre comme exemple un composant `User` qui prend en paramètre un `name` et une `imageSrc` qui peut être facultative.
 
 Une solution peut être d’utiliser le type option explicitement comme type de paramètre.
 
 ```reason
-/* UserRow.re */
+/* User.re */
 [@react.component]
 let make = (~name: string, ~imageSrc: option(string)) => {
   <div>
     <div>
       {imageSrc
        ->Belt.Option.map(src => <img src />)
-       ->Belt.Option.getWithDefault(ReasonReact.null)}
+       ->Belt.Option.getWithDefault(React.null)}
     </div>
-    <div> name->ReasonReact.string </div>
+    <div> name->React.string </div>
   </div>;
 };
 ```
 
-À l’intérieur du composant le type option est parfait pour gérer l’optionalité du paramètre. Mais à l’usage nous sommes obligé de l’utiliser de cette manière :
+À l’intérieur du composant le type option est parfait pour gérer l’optionalité du paramètre. En l'état, nous sommes obligé de l’utiliser de cette manière :
 
 ```reason
-<UserRow name="Ariel" imageSrc={Some("https://example.com/user.jpg")} />
+<User name="Ariel" imageSrc={Some("https://example.com/user.jpg")} />
 
-<UserRow name="Manon" imageSrc={None} />
+<User name="Manon" imageSrc={None} />
 ```
 
 Il est impossible d’omettre le paramètre `imageSrc`. Il faudra obligatoirement lui renseigner un option. Pour rendre le renseignement du paramètre vraiment optionnel, on peut utiliser le point d'interrogation comme valeur par défaut dans la déclaration du composant.
 
 ```reason
-/* UserRow.re */
+/* User.re */
 [@react.component]
 let make = (~name: string, ~imageSrc: option(string)=?) => { … };
 ```
@@ -45,9 +45,9 @@ let make = (~name: string, ~imageSrc: option(string)=?) => { … };
 Le point d'interrogation va permettre de renseigner directement le type inclus dans l’option (ici un string) ou d’omettre complètement le paramètre, ce qui donne ceci à l'usage :
 
 ```reason
-<UserRow name="Ariel" imageSrc="https://example.com/user.jpg" />
+<User name="Ariel" imageSrc="https://example.com/user.jpg" />
 
-<UserRow name="Manon" />
+<User name="Manon" />
 ```
 
 La valeur sera **automatiquement encapsulée dans un option**, ce qui fait que l’implémentation ne change pas et on profite toujours des avantages du type option dans le composant.
@@ -56,32 +56,32 @@ La valeur sera **automatiquement encapsulée dans un option**, ce qui fait que l
 
 Là on pourrait se dire que c’est bon c’est fini, mais en fait pas vraiment.
 
-Si on résume, notre component accepte en paramètre que `imageSrc` soit absent, ou qu’il soit un string. Mais impossible de lui donner un option, et cela peut être embêtant à l’usage.
+Si on résume, notre component accepte en paramètre que `imageSrc` soit absent, ou qu’il soit un string. Mais à première vue, impossible de lui donner un option, et cela peut être embêtant à l’usage.
 
-Par exemple, `UserRow` est utilisé dans un autre composant `FollowerRow` qui lui prend en paramètre un `avatarUrl`, et qui sera un type option. Pour transmettre la valeur de `avatarUrl` à `imageSrc` nous seront obligé de faire quelque chose comme ça :
+Par exemple, `User` est utilisé dans un autre composant `Follower` qui lui prend en paramètre un `avatarUrl`, et qui sera un type option. Pour transmettre la valeur de `avatarUrl` à `imageSrc` nous seront obligé de faire quelque chose comme ça :
 
 ```reason
-/* FollowerRow.re */
+/* Follower.re */
 [@react.component]
 let make = (~name: string, ~avatarUrl: option(string)=?) =>
   <div>
     {avatarUrl
-    ->Belt.Option.map(url => <UserRow name imageSrc={url} />)
-    ->Belt.Option.getWithDefault(<UserRow name />)}
+    ->Belt.Option.map(url => <User name imageSrc={url} />)
+    ->Belt.Option.getWithDefault(<User name />)}
   </div>;
 ```
 
-Vu que `imageSrc` ne prend pas de type option, on est obligé d'appeler `<UserRow>` différement selon que `avatarUrl` soit `Some()` ou `None`.
+Vu que `imageSrc` ne prend pas de type option, on est obligé d'appeler `<User>` différement selon que `avatarUrl` soit `Some()` ou `None`.
 
-Mais heureusement il existe une notation qui va nous permettre de renseigner un option, c’est là encore le point d'interrogation :
+Heureusement il existe une notation qui va nous permettre de renseigner un option, et on retrouve là encore le point d'interrogation :
 
 ```reason
-<UserRow name imageSrc=?{avatarUrl} />
+<User name imageSrc=?{avatarUrl} />
 ```
 
 Le point d'interrogation va permettre de renseigner le paramètre avec un type option, de transmettre la valeur contenue dans le `Some()` de `avatarUrl` ou d’omettre complètement le paramètre `imageSrc` si `avatarUrl` est `None`.
 
-## Double usage du point d'interrogation
+## Deux usages du point d'interrogation
 
 Si on résume, le premier point d'interrogation, celui utilisé pour donner une valeur option à un paramètre optionnel permet de **renseigner directement la valeur ou d’omettre le paramètre**.
 
@@ -106,7 +106,7 @@ On peut aussi l’utiliser avec le point d'interrogation, par exemple :
 [@react.component]
 let make = (~name: string, ~avatarUrl as imageSrc:option(string)=?) =>
   <div>
-    <UserRow name imageSrc=?{imageSrc} />
+    <User name imageSrc=?{imageSrc} />
   </div>;
 ```
 
@@ -116,7 +116,7 @@ devient
 [@react.component]
 let make = (~name: string, ~avatarUrl as imageSrc:option(string)=?) =>
   <div>
-    <UserRow name ?imageSrc />
+    <User name ?imageSrc />
   </div>;
 ```
 
@@ -129,20 +129,20 @@ C’est aussi l’occasion d’aborder le fait de pouvoir renommer un argument a
 L’inférence de type est vraiment très bonne en Reason, si j’ai explicité le type option et leur contenu string, je peux très bien m’en passer. Ce qui nous donne un exemple finale moins verbeux :
 
 ```reason
-/* UserRow.re */
+/* User.re */
 [@react.component]
 let make = (~name, ~imageSrc=?) =>
   <div>
     <div>
       {imageSrc
       ->Belt.Option.map(src => <img src />)
-      ->Belt.Option.getWithDefault(ReasonReact.null)}
+      ->Belt.Option.getWithDefault(React.null)}
     </div>
-    <div> name->ReasonReact.string </div>
+    <div> name->React.string </div>
   </div>;
 
-/* FollowerRow.re */
+/* Follower.re */
 [@react.component]
 let make = (~name, ~avatarUrl as imageSrc=?) =>
-  <div> <UserRow name ?imageSrc /> </div>;
+  <div> <User name ?imageSrc /> </div>;
 ```

--- a/articles/2019-05-26-type-option-et-point-d-interrogation.md
+++ b/articles/2019-05-26-type-option-et-point-d-interrogation.md
@@ -1,11 +1,11 @@
 ---
 date: 2019-05-26
-title: ReasonML type option et passage optionnel
+title: Les paramètres optionnels avec ReasonML
 author: freddy03h
-slug: reasonml-type-option-et-passage-optionnel
+slug: les-parametres-optionnels-avec-reasonml
 ---
 
-Le type option est vraiment super à utiliser en Reason, je vous conseil la lecture de [l'introduction à reasonml](/articles/introduction-a-reasonml) (et tous les autres articles sur Reason). Mais j’ai un peu buté sur un petit point, c'est celle de la **combinaison du type option** et de l’utilisation du **point d'interrogation** pour les **paramètres optionnels** d’une fonction ou d’un composant React [malgré la doc à ce sujet](https://reasonml.github.io/docs/en/function#optional-labeled-arguments), alors je résume cela dans cet article.
+Le type option est vraiment super à utiliser en Reason, je vous conseille la lecture de [l'introduction à ReasonML](/articles/introduction-a-reasonml) et [l'article sur le type option](/articles/le-type-option-c-est-quoi-et-ca-regle-quel-probleme). Mais j’ai un peu buté sur un petit point, c'est le lien entre les types option et les paramètres optionnels d’une fonction ou d’un composant React [malgré la doc à ce sujet](https://reasonml.github.io/docs/en/function#optional-labeled-arguments), alors je résume cela dans cet article.
 
 On va prendre comme exemple un composant `User` qui prend en paramètre un `name` et une `imageSrc` qui peut être facultative.
 
@@ -34,7 +34,7 @@ let make = (~name: string, ~imageSrc: option(string)) => {
 <User name="Manon" imageSrc={None} />
 ```
 
-Il est impossible d’omettre le paramètre `imageSrc`. Il faudra obligatoirement lui renseigner un option. Pour rendre le renseignement du paramètre vraiment optionnel, on peut utiliser le point d'interrogation comme valeur par défaut dans la déclaration du composant.
+Il est impossible d’omettre le paramètre `imageSrc`. Il faudra obligatoirement lui renseigner un option. Pour rendre le renseignement du paramètre vraiment optionnel, on peut déclarer le paramètre comme étant optionnel avec la syntaxe du point d'interrogation.
 
 ```reason
 /* User.re */
@@ -81,24 +81,24 @@ Heureusement il existe une notation qui va nous permettre de renseigner un optio
 
 Le point d'interrogation va permettre de renseigner le paramètre avec un type option, de transmettre la valeur contenue dans le `Some()` de `avatarUrl` ou d’omettre complètement le paramètre `imageSrc` si `avatarUrl` est `None`.
 
-## Deux usages du point d'interrogation
+## Deux syntaxes utilisant le point d'interrogation
 
-Si on résume, le premier point d'interrogation, celui utilisé pour donner une valeur option à un paramètre optionnel permet de **renseigner directement la valeur ou d’omettre le paramètre**.
+Si on résume, la première syntaxe qui s'utilise dans la déclaration d'une fonction permet de déclarer un paramètre comme optionnel, **la fonction acceptera de recevoir une valeur, comme il acceptera qu'on n'en passe aucune**.
 
-Et ensuite, le deuxième point d'interrogation, celui utilisé dans la déclaration d’optionalité du paramètre du composant, permet lui de **ré-encapsuler la valeur (ou l’absence de valeur) dans un type option**.
+Ensuite, la seconde syntaxe qui s'utilise à l'appel d'une fonction permet de **transformer une valeur de type option en paramètre optionnel**.
 
 Dis comme ça, cela peut sembler inutilement complexe, sauf que **la complexité est gérée par le langage**, et qu’à l’utilisation on y gagne en souplesse :
 
 - J’ai un composant avec un paramètre optionnel que je peux gérer, en interne, grâce aux avantages du type option
 - Je peux renseigner ce paramètre avec une valeur string, option ou l’omettre.
 
-## Notation raccourcis et typage
+## Notations raccourcis et typage
 
 Pour les besoins de l’exemple j’ai volontairement utilisé du code très explicite, mais il faut savoir qu’on a quelques raccourcis dans la notation.
 
 ### Punning
 
-L’avantage du JSX de ReasonReact par rapport à React.js c’est le punning. Le raccouris quand un label et la valeur sont le même. On a déjà l’habitude en JS avec les objets, au lieu de `return {name: name}`, on peut faire `return {name}`.
+L’avantage du JSX de ReasonReact par rapport à React.js, c’est le punning. Le raccourci lorsqu'on a une prop ayant le même nom que la variable qu'on y passe. On a déjà l’habitude en JS avec les objets, au lieu de `return {name: name}`, on peut faire `return {name}`.
 
 On peut aussi l’utiliser avec le point d'interrogation, par exemple :
 
@@ -122,7 +122,7 @@ let make = (~name: string, ~avatarUrl as imageSrc:option(string)=?) =>
 
 (d’ailleurs, si vous écrivez le code sans punning, le Reformat vous réécrit automatiquement votre code avec).
 
-C’est aussi l’occasion d’aborder le fait de pouvoir renommer un argument avec `as`. Il ne faut vraiment pas s’en priver. En fait il faut savoir que `(~name)` est lui même un raccourcis pour `(~name as name)`.
+C’est aussi l’occasion d’aborder le fait de pouvoir renommer un argument avec `as`. Il ne faut vraiment pas s’en priver. En fait il faut savoir que `(~name)` est lui même un raccourci pour `(~name as name)`.
 
 ### Inférence de type
 
@@ -146,3 +146,8 @@ let make = (~name, ~imageSrc=?) =>
 let make = (~name, ~avatarUrl as imageSrc=?) =>
   <div> <User name ?imageSrc /> </div>;
 ```
+
+Le type option se révèle très pratique lors de l'écriture d'un fonction ou d'un component. Les paramètres optionnels, avec les deux syntaxes utilisant le point d'interrogation, permettent de ne pas compléxifier l'usage de la fonction ou du component.
+
+Dans l'exemple final, l'implémentation de `User` n'a pas changé depuis le début car nous voulons gérer l'aspect facultatif du paramètre. En revanche `Follower` n'avait absoluement pas besoin de le gérer dans son implémentation, le code s'en serait trouvé inutilement alourdis.
+Nous gardons ainsi une écriture fluide tout en permettant de gérer l'optionnalité d'une valeur lorsque cela est nécessaire.

--- a/articles/2019-05-26-type-option-et-point-d-interrogation.md
+++ b/articles/2019-05-26-type-option-et-point-d-interrogation.md
@@ -1,5 +1,5 @@
 ---
-date: 2019-05-26
+date: 2019-06-25
 title: Les paramètres optionnels avec ReasonML
 author: freddy03h
 slug: les-parametres-optionnels-avec-reasonml

--- a/articles/2019-05-26-type-option-et-point-d-interrogation.md
+++ b/articles/2019-05-26-type-option-et-point-d-interrogation.md
@@ -147,7 +147,7 @@ let make = (~name, ~avatarUrl as imageSrc=?) =>
   <div> <User name ?imageSrc /> </div>;
 ```
 
-Le type option se révèle très pratique lors de l'écriture d'un fonction ou d'un component. Les paramètres optionnels, avec les deux syntaxes utilisant le point d'interrogation, permettent de ne pas compléxifier l'usage de la fonction ou du component.
+Le type option se révèle très pratique lors de l'écriture d'un fonction ou d'un component. Les paramètres optionnels, avec les deux syntaxes utilisant le point d'interrogation, permettent de ne pas complexifier l'usage de la fonction ou du component.
 
 Dans l'exemple final, l'implémentation de `User` n'a pas changé depuis le début car nous voulons gérer l'aspect facultatif du paramètre. En revanche `Follower` n'avait absoluement pas besoin de le gérer dans son implémentation, le code s'en serait trouvé inutilement alourdis.
 Nous gardons ainsi une écriture fluide tout en permettant de gérer l'optionnalité d'une valeur lorsque cela est nécessaire.

--- a/articles/2019-05-26-type-option-et-point-d-interrogation.md
+++ b/articles/2019-05-26-type-option-et-point-d-interrogation.md
@@ -1,0 +1,148 @@
+---
+date: 2019-05-26
+title: Type option et point d'interrogation
+author: freddy03h
+slug: type-option-et-point-d-interrogation
+---
+
+Le type option est vraiment super à utiliser en Reason, je vous conseil la lecture de [l’article de Matthias](/articles/introduction-a-reasonml) (et tous les autres articles sur Reason). Mais j’ai un peu buté sur un petit point, c'est celle de la **combinaison du type option** et de l’utilisation du **point d'interrogation** pour les **paramètres optionnels** d’une fonction ou d’un composant React [malgré la doc à ce sujet](https://reasonml.github.io/docs/en/function#optional-labeled-arguments), alors je résume cela dans cet article.
+
+On va prendre comme exemple un composant `UserRow` qui prend en paramètre un `name` et une `imageSrc` qui peut être facultative.
+
+Une solution peut être d’utiliser le type option explicitement comme type de paramètre.
+
+```reason
+/* UserRow.re */
+[@react.component]
+let make = (~name: string, ~imageSrc: option(string)) => {
+  <div>
+    <div>
+      {imageSrc
+       ->Belt.Option.map(src => <img src />)
+       ->Belt.Option.getWithDefault(ReasonReact.null)}
+    </div>
+    <div> name->ReasonReact.string </div>
+  </div>;
+};
+```
+
+À l’intérieur du composant le type option est parfait pour gérer l’optionalité du paramètre. Mais à l’usage nous sommes obligé de l’utiliser de cette manière :
+
+```reason
+<UserRow name="Ariel" imageSrc={Some("https://example.com/user.jpg")} />
+
+<UserRow name="Manon" imageSrc={None} />
+```
+
+Il est impossible d’omettre le paramètre `imageSrc`. Il faudra obligatoirement lui renseigner un option. Pour rendre le renseignement du paramètre vraiment optionnel, on peut utiliser le point d'interrogation comme valeur par défaut dans la déclaration du composant.
+
+```reason
+/* UserRow.re */
+[@react.component]
+let make = (~name: string, ~imageSrc: option(string)=?) => { … };
+```
+
+Le point d'interrogation va permettre de renseigner directement le type inclus dans l’option (ici un string) ou d’omettre complètement le paramètre, ce qui donne ceci à l'usage :
+
+```reason
+<UserRow name="Ariel" imageSrc="https://example.com/user.jpg" />
+
+<UserRow name="Manon" />
+```
+
+La valeur sera **automatiquement encapsulée dans un option**, ce qui fait que l’implémentation ne change pas et on profite toujours des avantages du type option dans le composant.
+
+## Bon alors c'est tout ?
+
+Là on pourrait se dire que c’est bon c’est fini, mais en fait pas vraiment.
+
+Si on résume, notre component accepte en paramètre que `imageSrc` soit absent, ou qu’il soit un string. Mais impossible de lui donner un option, et cela peut être embêtant à l’usage.
+
+Par exemple, `UserRow` est utilisé dans un autre composant `FollowerRow` qui lui prend en paramètre un `avatarUrl`, et qui sera un type option. Pour transmettre la valeur de `avatarUrl` à `imageSrc` nous seront obligé de faire quelque chose comme ça :
+
+```reason
+/* FollowerRow.re */
+[@react.component]
+let make = (~name: string, ~avatarUrl: option(string)=?) =>
+  <div>
+    {avatarUrl
+    ->Belt.Option.map(url => <UserRow name imageSrc={url} />)
+    ->Belt.Option.getWithDefault(<UserRow name />)}
+  </div>;
+```
+
+Vu que `imageSrc` ne prend pas de type option, on est obligé d'appeler `<UserRow>` différement selon que `avatarUrl` soit `Some()` ou `None`.
+
+Mais heureusement il existe une notation qui va nous permettre de renseigner un option, c’est là encore le point d'interrogation :
+
+```reason
+<UserRow name imageSrc=?{avatarUrl} />
+```
+
+Le point d'interrogation va permettre de renseigner le paramètre avec un type option, de transmettre la valeur contenue dans le `Some()` de `avatarUrl` ou d’omettre complètement le paramètre `imageSrc` si `avatarUrl` est `None`.
+
+## Double usage du point d'interrogation
+
+Si on résume, le premier point d'interrogation, celui utilisé pour donner une valeur option à un paramètre optionnel permet de **renseigner directement la valeur ou d’omettre le paramètre**.
+
+Et ensuite, le deuxième point d'interrogation, celui utilisé dans la déclaration d’optionalité du paramètre du composant, permet lui de **ré-encapsuler la valeur (ou l’absence de valeur) dans un type option**.
+
+Dis comme ça, cela peut sembler inutilement complexe, sauf que **la complexité est gérée par le langage**, et qu’à l’utilisation on y gagne en souplesse :
+
+- J’ai un composant avec un paramètre optionnel que je peux gérer, en interne, grâce aux avantages du type option
+- Je peux renseigner ce paramètre avec une valeur string, option ou l’omettre.
+
+## Notation raccourcis et typage
+
+Pour les besoins de l’exemple j’ai volontairement utilisé du code très explicite, mais il faut savoir qu’on a quelques raccourcis dans la notation.
+
+### Punning
+
+L’avantage du JSX de ReasonReact par rapport à React.js c’est le punning. Le raccouris quand un label et la valeur sont le même. On a déjà l’habitude en JS avec les objets, au lieu de `return {name: name}`, on peut faire `return {name}`.
+
+On peut aussi l’utiliser avec le point d'interrogation, par exemple :
+
+```reason
+[@react.component]
+let make = (~name: string, ~avatarUrl as imageSrc:option(string)=?) =>
+  <div>
+    <UserRow name imageSrc=?{imageSrc} />
+  </div>;
+```
+
+devient
+
+```reason
+[@react.component]
+let make = (~name: string, ~avatarUrl as imageSrc:option(string)=?) =>
+  <div>
+    <UserRow name ?imageSrc />
+  </div>;
+```
+
+(d’ailleurs, si vous écrivez le code sans punning, le Reformat vous réécrit automatiquement votre code avec).
+
+C’est aussi l’occasion d’aborder le fait de pouvoir renommer un argument avec `as`. Il ne faut vraiment pas s’en priver. En fait il faut savoir que `(~name)` est lui même un raccourcis pour `(~name as name)`.
+
+### Inférence de type
+
+L’inférence de type est vraiment très bonne en Reason, si j’ai explicité le type option et leur contenu string, je peux très bien m’en passer. Ce qui nous donne un exemple finale moins verbeux :
+
+```reason
+/* UserRow.re */
+[@react.component]
+let make = (~name, ~imageSrc=?) =>
+  <div>
+    <div>
+      {imageSrc
+      ->Belt.Option.map(src => <img src />)
+      ->Belt.Option.getWithDefault(ReasonReact.null)}
+    </div>
+    <div> name->ReasonReact.string </div>
+  </div>;
+
+/* FollowerRow.re */
+[@react.component]
+let make = (~name, ~avatarUrl as imageSrc=?) =>
+  <div> <UserRow name ?imageSrc /> </div>;
+```


### PR DESCRIPTION
Hello, j'ai écris un petit post sur l'utilisation du type option et du point d'interrogation avec les paramètres optionnels d'une fonction.

J'avais buté sur le sujet, appris le truc, mais comme je ne fais pas encore du Reason régulièrement, quand j'ai repris je me suis repris les pieds dans le tapis de la même manière alors je me suis fais un memo perso, et je me suis dis que ça pouvait faire l'objet d'un article.

J'ai besoin de vous, déjà pour la relecture technique si je dis pas de conneries, mais aussi pour tout le reste, car j'ai pas l'habitude de l'exercice d'écriture et c'est mon premier post sur ce blog.

J'ai quelques questions :
- J'ai mis la date du jour mais on changera au moment de publier (enfin, si l'article vous intéresse) c'est ça ?
- J'ai utilisé des fonctions de `Belt.Option` parce que je me dis que les lecteurs auront lu les articles de Matthias concernant Reason et particulièrement celui sur le type option dont je re-mets le lien en haut de l'article. Mais finalement, je doute, et je me dis qu'un `switch` est peut être plus facilement compréhensible par tous. Vous en pensez quoi ?

Voilà merci !